### PR TITLE
updated boto3 package

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,6 +6,7 @@ mock==3.0.5
 # PyMongo and Athena dependencies are needed for some of the unit tests:
 # (this is not perfect and we should resolve this in a different way)
 pymongo[srv,tls]==3.9.0
+boto3>=1.10.0,<1.11.0
 botocore>=1.13,<1.14.0
 PyAthena>=1.5.0
 ptvsd==4.3.2


### PR DESCRIPTION
issue
while logging using saml have issue due to boto3 package deprecation
ImportError: cannot import name 'DEPRECATED_SERVICE_NAMES' from 'botocore.docs

When it comes to SAML configuration in Redash, Boto3 can be used indirectly. Here's how:
Identity Provider (IdP) Setup: To configure SAML authentication in Redash, you need to set up an Identity Provider (IdP) that handles the authentication process. This could be a service like Okta, Azure AD, or another SAML-compliant provider. The setup process typically involves configuring the IdP settings and obtaining the necessary metadata.
AWS SSO (Single Sign-On): In some cases, organizations use AWS Single Sign-On (SSO) as their central identity provider. Boto3 can be used to configure AWS SSO and set up the necessary trust relationship between AWS SSO and the IdP used for Redash SAML authentication.
Redash SAML Configuration: Once the IdP setup and AWS SSO configuration (if applicable) are complete, you'll need to configure Redash to use SAML authentication. This involves updating Redash's configuration file with the appropriate SAML-related settings, such as the IdP metadata URL, SAML endpoint URLs, and certificate information.